### PR TITLE
YRewrite-List-EP: Richtige id verwenden im Link zur Domain

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -38,21 +38,24 @@ rex_extension::register('REX_LIST_GET', static function (rex_extension_point $ep
         $_csrf_key = $table->getCSRFKey();
         $token = rex_csrf_token::factory($_csrf_key)->getUrlParams();
 
-        $params = [];
+        
+        $domain = Domain::query()
+            ->where('yrewrite_domain_id', $a['list']->getValue('id'))
+            ->findOne();
+
+            $params = [];
         $params['table_name'] = 'rex_yrewrite_metainfo';
         $params['rex_yform_manager_popup'] = '0';
         $params['_csrf_token'] = $token['_csrf_token'];
-        $params['data_id'] = $a['list']->getValue('id');
         $params['func'] = 'add';
 
-        $domain = Domain::get($a['list']->getValue('id'));
-        if ($domain instanceof Domain) {
+
+        if ($domain !== null) {
+            $params['data_id'] = $domain->getId();
             $params['func'] = 'edit';
             return '<a href="' . rex_url::backendPage('yrewrite/metainfo/domain', $params) . '">' . rex_i18n::msg('yrewrite_metainfo_edit') . '</a>';
         }
-        // Link zu Neue YRewrite-Metainfo-Domain erstellen
-        // https://blaupause.test/redaxo/index.php?func=add&page=yrewrite%2Fmetainfo%2Fdomain&table_name=rex_yrewrite_metainfo&list=&sort=&sorttype=&start=0&_csrf_token=s_AUawHLnRx4uZib-ACHIs9nnbd0tpYpHQP_Vb4PxAg&rex_yform_manager_popup=0
-
+        // Link zu neuer YRewrite-Metainfo-Domain erstellen
         return '<a href="' . rex_url::backendPage('yrewrite/metainfo/domain', $params) . '">' . rex_i18n::msg('yrewrite_metainfo_add') . '</a>';
     });
     return $list;


### PR DESCRIPTION
Vorher wurde die id der YRewrite-Domain, nicht der MetaInfo-Domain in der Übersicht verwendet